### PR TITLE
Relaunch shell after it exits

### DIFF
--- a/base_img/init_functions
+++ b/base_img/init_functions
@@ -51,7 +51,7 @@ launch_interactive_shell() {
 	
 	{
 		[ "$1" = "--exec" ] && exec login $USER
-		login $USER
+		while `true`; do login $USER; done
 	}
 }
 


### PR DESCRIPTION
If you exit the shell from the console of the recovery environment, or don't log in promptly, the login command will exit and this will cause the init process to exit, which panics the system. We need to prevent that, by looping over the login command.