### PR TITLE
Add zfs utilities

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -17,9 +17,10 @@ mknod -m 600 ./dev/console c 5 1
 
 modpath="/lib/modules/$(uname -r)/"
 mkdir -p "./$modpath/kernel/drivers/"
-rsync -a "/$modpath"/modules* ."/$modpath/"
+rsync -a "/$modpath"/modules* "./$modpath/"
 rsync -a "/$modpath/vdso" "./$modpath/"
-cp -r "/$modpath"/kernel/drivers/{char,misc,tty,net} "./$modpath/kernel/drivers/"
+rsync -a "/$modpath/extra" "./$modpath/"
+rsync -a "/$modpath/kernel/drivers" "./$modpath/kernel/"
 
 if [[ $(cat /var/lib/delphix-appliance/platform) == "gcp" ]]; then
 	rsync -a "/$modpath/kernel/net/" "./$modpath/kernel/net/"

--- a/scripts/stage1.sh
+++ b/scripts/stage1.sh
@@ -51,6 +51,7 @@ target="$1"
 workdir=$(mktemp -d)
 img="$workdir/img"
 base="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+repo="$(pwd)"
 
 #
 # Set up working directory
@@ -63,13 +64,14 @@ PACKAGES="dropbear-bin \
 	busybox-static \
 	kmod \
 	systemd \
-	udev "
+	udev \
+	libssl1.1"
 
 apt-get download $(apt-cache depends --recurse --no-recommends --no-suggests \
 	--no-conflicts --no-breaks --no-replaces --no-enhances \
 	${PACKAGES} | grep "^\w")
 
-for file in *.deb; do dpkg-deb -x "$file" .; done
+for file in *.deb "$repo"/external-debs/*.deb; do dpkg-deb -x "$file" .; done
 
 #
 # Perform installation process
@@ -81,7 +83,8 @@ mkdir -p "$img/bin/"
 
 for file in /bin/busybox /bin/kmod /bin/systemd-tmpfiles /bin/udevadm \
 	/lib/systemd/systemd-networkd /lib/systemd/systemd-udevd \
-	/usr/sbin/dropbear /usr/lib/dropbear/dropbearconvert; do
+	/usr/sbin/dropbear /usr/lib/dropbear/dropbearconvert /sbin/zfs \
+	/sbin/zpool /sbin/zdb; do
 	mkdir -p "$img/$(dirname $file)"
 	rsync -a "$workdir/$file" "$img/$file"
 	get_deps "$img/$file" "$img"


### PR DESCRIPTION
This PR adds the ZFS utilities to the recovery environment, so we can import and modify pools as needed in order to prevent further failed boots. This PR is intended to merged in conjunction with https://github.com/delphix/linux-pkg/pull/102. It was tested with ab-pre-push, and by loading the built recovery environment onto a test VM to verify functionality.