### PR TITLE
Install base image to separate location to satisfy debsums

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 	install -D scripts/recovery_sync \
 		$(DESTDIR)$(prefix)/bin/recovery_sync
 	install -D bin/recovery.img \
-		$(DESTDIR)/boot/recovery.img
+		$(DESTDIR)/$(prefix)/share/recovery_environment/recovery.img
 	install -D scripts/42_bootcount \
 		$(DESTDIR)/etc/grub.d/42_bootcount
 	install -D scripts/42_recovery \

--- a/debian/postinst
+++ b/debian/postinst
@@ -5,13 +5,14 @@ function die() {
 	exit 1
 }
 
+base_img="/usr/share/recovery_environment/recovery.img"
 target="/boot/recovery.img"
 workdir=$(mktemp -d)
 
 cd "$workdir" || die "workdir doesn't exist"
 chown root .
 chmod 0755 .
-gunzip <"$target" | cpio -idm
+gunzip <"$base_img" | cpio -idm
 
 mknod -m 600 ./dev/console c 5 1
 


### PR DESCRIPTION
The debsums -c check we do as part of the appliance build process fails when the recovery.img file is modified as part of the postinst and recovery_sync steps. We should install the base recovery.img file to a different location and create a new copy in postinst that will actually be used to boot the system.