### PR TITLE
Write to temporary file, mv atomically to target

### DIFF
--- a/scripts/delphix-bootcount.service
+++ b/scripts/delphix-bootcount.service
@@ -3,7 +3,7 @@
 #
 
 [Unit]
-Descrption=Delphix bootcount reset service
+Description=Delphix bootcount reset service
 Requires=ssh.service
 After=ssh.service
 

--- a/scripts/recovery_sync
+++ b/scripts/recovery_sync
@@ -9,6 +9,11 @@
 
 set -euxo pipefail
 
+function cleanup() {
+	rm -rf "$workdir"
+	rm -f "${target}.tmp"
+}
+
 function die() {
 	echo "$1" >&2
 	exit 1
@@ -17,6 +22,7 @@ function die() {
 [[ $# -eq 1 ]] || die "Illegal number of parameters"
 target="$1"
 workdir=$(mktemp -d)
+trap cleanup EXIT
 
 cd "$workdir"
 chown root .
@@ -40,4 +46,5 @@ done
 rsync -a /etc/machine-id etc/
 rsync -a --relative /export/home/delphix/.ssh .
 
-find . -print0 | cpio --null --create --format=newc | gzip -7 >"$target"
+find . -print0 | cpio --null --create --format=newc | gzip -7 >"${target}.tmp"
+mv "${target}.tmp" "$target"


### PR DESCRIPTION
This fixes an issue where the recovery environment can become corrupted if the system goes down while we're syncing the recovery environment.