### PR TITLE
DLPX-71356 [Backport of DLPX-71297 to 6.0.4.0] delphix-bootcount service fails to start on master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ all:
 	./scripts/stage1.sh $(CURDIR)/bin/recovery.img
 
 install:
+	install -D scripts/bootcount_reset \
+		$(DESTDIR)$(prefix)/bin/bootcount_reset
 	install -D scripts/recovery_sync \
 		$(DESTDIR)$(prefix)/bin/recovery_sync
 	install -D bin/recovery.img \
@@ -23,6 +25,7 @@ clean:
 distclean: clean
 
 uninstall:
+	-rm -f $(DESTDIR)/$(prefix)/bin/bootcount_reset
 	-rm -f $(DESTDIR)/$(prefix)/bin/recovery_sync
 	-rm -f $(DESTDIR)/$(prefix)/share/recovery_environment/recovery.img
 	-rm -f $(DESTDIR)/etc/grub.d/42_bootcount

--- a/scripts/bootcount_reset
+++ b/scripts/bootcount_reset
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+function die() {
+	echo "$1" >&2
+	exit 1
+}
+
+/usr/bin/grub-editenv /boot/grub/grubenv set bootcount=0 2>/dev/null && exit 0
+/usr/bin/grub-editenv /boot/grub/grubenv create || die "Could not create grubenv"
+/usr/bin/grub-editenv /boot/grub/grubenv set bootcount=0 || die "Could not set boot count to zero"

--- a/scripts/delphix-bootcount.service
+++ b/scripts/delphix-bootcount.service
@@ -6,12 +6,13 @@
 Description=Delphix bootcount reset service
 Requires=ssh.service
 After=ssh.service
+ConditionVirtualization=!container
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 ExecStartPre=/bin/sleep 300
-ExecStart=/usr/bin/grub-editenv /boot/grub/grubenv set bootcount=0
+ExecStart=/usr/bin/bootcount_reset
 
 [Install]
 WantedBy=delphix.target


### PR DESCRIPTION
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3892/ (in progress)

Clean cherry-pick from master