### PR TITLE
DLPX-71720 [Backport of DLPX-71708 to 6.0.4.0] Recovery environment fails to boot

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC1091
 
 function die() {
 	echo "$1" >&2
@@ -16,7 +17,20 @@ gunzip <"$base_img" | cpio -idm
 
 mknod -m 600 ./dev/console c 5 1
 
-modpath="/lib/modules/$(uname -r)/"
+. /usr/lib/grub/grub-mkconfig_lib
+
+#
+# Determine the latest installed kernel version, and sync kernel modules for
+# that version into the recovery environment.
+#
+list=
+for i in /boot/vmlinuz-*; do
+	if grub_file_is_not_garbage "$i"; then list="$list $i"; fi
+done
+linux=$(version_find_latest "$list")
+basename=$(basename "$linux")
+
+modpath="/lib/modules/${basename#vmlinuz-}"
 mkdir -p "./$modpath/kernel/drivers/"
 rsync -a "/$modpath"/modules* "./$modpath/"
 rsync -a "/$modpath/vdso" "./$modpath/"

--- a/scripts/42_recovery
+++ b/scripts/42_recovery
@@ -5,6 +5,17 @@ set -e
 
 . /usr/lib/grub/grub-mkconfig_lib
 
+#
+# Determine the latest installed kernel version, and use that version as the
+# kernel for the recovery environment.
+#
+list=
+for i in /boot/vmlinuz-*; do
+	if grub_file_is_not_garbage "$i"; then list="$list $i"; fi
+done
+linux=$(version_find_latest "$list")
+basename=$(basename "$linux")
+
 cat <<EOF
 menuentry 'Recovery Environment' --class ubuntu --class gnu-linux --class gnu --class os --id 'recovery' {
     recordfail
@@ -20,7 +31,7 @@ root=$(findmnt / | grep '^/' | awk '{print $2}' | sed 's@^rpool/@@')
 
 cat <<EOF
     echo    'Loading recovery environment'
-    linux   /${root}@/boot/vmlinuz-$(uname -r)  root=ZFS=rpool/$root ro single nomodeset console=tty0 console=ttyS0,38400n8 break=y
+    linux   /${root}@/boot/${basename}  root=ZFS=rpool/$root ro single nomodeset console=tty0 console=ttyS0,38400n8 break=y
     initrd  /${root}@/boot/recovery.img
 }
 EOF

--- a/scripts/bootcount_reset
+++ b/scripts/bootcount_reset
@@ -6,5 +6,8 @@ function die() {
 }
 
 /usr/bin/grub-editenv /boot/grub/grubenv set bootcount=0 2>/dev/null && exit 0
+
+# Perform firstboot/corruption case logic
 /usr/bin/grub-editenv /boot/grub/grubenv create || die "Could not create grubenv"
 /usr/bin/grub-editenv /boot/grub/grubenv set bootcount=0 || die "Could not set boot count to zero"
+/usr/bin/recovery_sync /boot/recovery.img || die "could not sync recovery environment"


### PR DESCRIPTION
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3951/console

Manual testing performed with an ab-pre-push VM; machine was rebooted repeatedly until it entered the recovery environment, at which time ssh and http connectivity was verified. The package was then reinstalled, to emulate the upgrade workflow, and the test was repeated. All tests were successful.