### PR TITLE
DLPX-71777 Recovery environment is unreachable from network

### DIFF
--- a/scripts/recovery_sync
+++ b/scripts/recovery_sync
@@ -30,6 +30,7 @@ chmod 0755 .
 gunzip <"$target" | cpio -idm
 
 rsync -a /run/systemd/network/ etc/systemd/network
+rsync -a /lib/systemd/network/ lib/systemd/network
 mkdir -p etc/dropbear
 rsync -a /opt/delphix/server/etc/nginx.default ./opt/delphix/server/etc/
 rsync -a /opt/delphix/server/etc/nginx ./opt/delphix/server/etc/


### PR DESCRIPTION
Testing: 
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3983/console (in progress)

Cloned ab-pre-push VM, verified that recovery environment was network reachable.

Evaluation:
By default, systemd uses the old style name scheme for network devices; this causes the first network interface on the Delphix Engine to be registered as eth0. A configuration file (/lib/systemd/network/99-default.link) causes systemd to use the kernel's provided name (ens160, on vmware) instead. This configuration file needs to be synced into the recovery environment as well, in order for the recovery environment to properly configure the system's network devices automatically.

This regression was triggered when a recent change was pushed that changed the Delphix Engine from using a MAC address matching system to identify devices, to one that relies on the kernel's deterministic naming scheme. While the MAC address approach worked correctly in both the normal DE and the recovery environment, the new name-matching scheme did not function in the recovery environment because the device was not being identified by the kernel's deterministic naming scheme.
