### PR TITLE
DLPX-71803 [Backport of DLPX-71777 to 6.0.5.0] Recovery environment i…

### DIFF
--- a/scripts/recovery_sync
+++ b/scripts/recovery_sync
@@ -30,6 +30,7 @@ chmod 0755 .
 gunzip <"$target" | cpio -idm
 
 rsync -a /run/systemd/network/ etc/systemd/network
+rsync -a /lib/systemd/network/ lib/systemd/network
 mkdir -p etc/dropbear
 rsync -a /opt/delphix/server/etc/nginx.default ./opt/delphix/server/etc/
 rsync -a /opt/delphix/server/etc/nginx ./opt/delphix/server/etc/


### PR DESCRIPTION
…s unreachable from network
This is a straight backport of the change to master; the cherry-pick is clean.

http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3984/ (in progress)