### PR TITLE
DLPX-72161 [Backport of DLPX-72155 to 6.0.4.2] Cancelled upgrades can render engine unbootable

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -58,9 +58,13 @@ ln -s /opt/delphix/server/etc/nginx/nginx.conf ./etc/nginx/nginx.conf
 
 find . -print0 | cpio --null --create --format=newc | gzip -7 >"$target" 2>/dev/null
 
-mount -t zfs rpool/grub /mnt
-/usr/sbin/grub-mkconfig -o /mnt/boot/grub/grub.cfg
-umount /mnt
+#
+# The grub config needs to be updated in order for the recovery environment to
+# function properly. However, we store our grub config file in a separate ZFS
+# filesystem, which resulted in a bug where we modified the grub config even
+# when doing an upgrade inside a container. As a result, we do not run
+# mkconfig in this script, and rely on the end-of-upgrade scripts to do it.
+#
 
 grub-editenv /boot/grub/grubenv create
 grub-editenv /boot/grub/grubenv set bootcount=0


### PR DESCRIPTION
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4119/console Failure appears environmental
Upgrade tests from 6.0.3.0 in progress http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/upgrade-testing/4031/console