### PR TITLE
DLPX-71822 recovery environment should have DNS configuration

### DIFF
--- a/base_img/hooks/networkd
+++ b/base_img/hooks/networkd
@@ -3,6 +3,7 @@
 run_hook() {
 	mkdir -p /run/systemd
 	/lib/systemd/systemd-networkd &
+	/lib/systemd/systemd-resolved &
 	export networkd_running=1
 }
 

--- a/scripts/recovery_sync
+++ b/scripts/recovery_sync
@@ -68,7 +68,8 @@ for fmt in $(find /etc/ssh -name \*key | sed 's/.*host_\(.*\)_key/\1/'); do
 		"etc/dropbear/dropbear_${fmt}_host_key"
 done
 
-rsync -a /etc/machine-id etc/
+rsync -a /etc/{machine-id,resolv.conf} etc/
+rsync -a /etc/systemd/ etc/systemd
 rsync -a --relative /export/home/delphix/.ssh .
 
 find . -print0 | cpio --null --create --format=newc | gzip -7 >"${target}.tmp"

--- a/scripts/stage1.sh
+++ b/scripts/stage1.sh
@@ -83,7 +83,7 @@ rsync -a ../base_img/ "$img/"
 mkdir -p "$img/bin/"
 
 for file in /bin/busybox /bin/kmod /bin/systemd-tmpfiles /bin/udevadm \
-	/lib/systemd/systemd-networkd /lib/systemd/systemd-udevd \
+	/lib/systemd/systemd-networkd /lib/systemd/systemd-udevd /lib/systemd/systemd-resolved \
 	/usr/sbin/dropbear /usr/lib/dropbear/dropbearconvert /sbin/zfs \
 	/sbin/zpool /sbin/zdb /usr/sbin/nginx; do
 	mkdir -p "$img/$(dirname $file)"


### PR DESCRIPTION
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4238/

Manually tested by adding a search domain to the DNS config, and then rebooting into the recovery environment that it was present there as well.