### PR TITLE
DLPX-74492 Resetting the bootcount fails with invalid environment block

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -66,9 +66,11 @@ find . -print0 | cpio --null --create --format=newc | gzip -7 >"$target" 2>/dev/
 # mkconfig in this script, and rely on the end-of-upgrade scripts to do it.
 #
 # Similary, the environment block in the bootloader is set by the bootcount
-# service after first boot. And the recovery environment will be synced when a
+# service after first boot, and the recovery environment will be synced when a
 # configuration change is made.
 #
+
+systemctl enable delphix-bootcount.service
 
 cd / || die "failed to cd /"
 rm -rf "$workdir"


### PR DESCRIPTION
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4825/console