### PR TITLE
Error swallowing commit & Follow-on backport to 6.0/stage

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 # shellcheck disable=SC1091
 
 function die() {
@@ -15,7 +15,7 @@ chown root .
 chmod 0755 .
 gunzip <"$base_img" | cpio -idm
 
-mknod -m 600 ./dev/console c 5 1
+mknod -m 600 ./dev/console c 5 1 || systemd-detect-virt -c
 
 . /usr/lib/grub/grub-mkconfig_lib
 
@@ -65,12 +65,12 @@ find . -print0 | cpio --null --create --format=newc | gzip -7 >"$target" 2>/dev/
 # when doing an upgrade inside a container. As a result, we do not run
 # mkconfig in this script, and rely on the end-of-upgrade scripts to do it.
 #
+# Similary, the environment block in the bootloader is set by the bootcount
+# service after first boot, and the recovery environment will be synced when a
+# configuration change is made.
+#
 
-grub-editenv /boot/grub/grubenv create
-grub-editenv /boot/grub/grubenv set bootcount=0
 systemctl enable delphix-bootcount.service
-
-/usr/bin/recovery_sync $target
 
 cd / || die "failed to cd /"
 rm -rf "$workdir"


### PR DESCRIPTION
DLPX-74568 [Backport of DLPX-74079 to 6.0.8.0] Recovery environment postinst script swallows errors
DLPX-74519 [Backport of DLPX-74492 to 6.0.8.0] Resetting the bootcount fails with invalid environment block

http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4848/