### PR TITLE
DLPX-75009 [Backport of DLPX-74575 tp 6.0.8.0] IBM/OCI: Recovery environment becomes unreachable

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -37,9 +37,11 @@ rsync -a "/$modpath/vdso" "./$modpath/"
 rsync -a "/$modpath/extra" "./$modpath/"
 rsync -a "/$modpath/kernel/drivers" "./$modpath/kernel/"
 
-if [[ $(cat /var/lib/delphix-appliance/platform) == "gcp" ]]; then
-	rsync -a "/$modpath/kernel/net/" "./$modpath/kernel/net/"
-fi
+case "$(cat /var/lib/delphix-appliance/platform)" in
+gcp | kvm | oci) rsync -a "/$modpath/kernel/net/" "./$modpath/kernel/net/" ;;
+esx | aws | azure | hyperv) echo "Skipping copying kernel/net drivers" ;;
+*) die "Unrecognized platform detected" ;;
+esac
 
 rm -rf "./$modpath/kernel/drivers/net/wireless"
 cp -r /lib/modules-load.d ./lib/


### PR DESCRIPTION
ab-pre-push run: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4968/ (error appears to be environmental)