### PR TITLE
DLPX-76730 delphix-bootcount.service failed due to a missing SSH file

### DIFF
--- a/scripts/recovery_sync
+++ b/scripts/recovery_sync
@@ -82,7 +82,8 @@ done
 
 rsync -a /etc/{machine-id,resolv.conf} etc/
 rsync -a /etc/systemd/ etc/systemd
-rsync -a --relative /export/home/delphix/.ssh .
+# .ssh may not exist on some platforms; don't fail if that's the case
+rsync -a --relative /export/home/delphix/.ssh . || true
 
 tmpfile=$(mktemp "${target}.XXXXX")
 find . -print0 | cpio --null --create --format=newc | gzip -7 >"$tmpfile"


### PR DESCRIPTION
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5802/

Manually tested on a VM with no .ssh directory, recovery sync still succeeded and the environment was still reachable (albeit with password instead of ssh keys).