### PR TITLE
DLPX-78981 rootfs out of space due to thousands of "recovery.img" files in "/boot"

### DIFF
--- a/scripts/recovery_sync
+++ b/scripts/recovery_sync
@@ -11,7 +11,7 @@ set -euxo pipefail
 
 function cleanup() {
 	rm -rf "$workdir"
-	rm -f "${target}.tmp"
+	[[ -n "$tmpfile" ]] && rm -f "$tmpfile"
 }
 
 function die() {


### PR DESCRIPTION
This PR fixes the cleanup logic in the recovery_sync script to properly delete the temporary files in the case where the script fails.

http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/306/ in progress