### PR TITLE
DLPX-79051 [Backport of DLPX-78981 to 6.0.13.0] rootfs out of space due to thousands of "recovery.img" files in "/boot" (#38)

### DIFF
--- a/scripts/recovery_sync
+++ b/scripts/recovery_sync
@@ -11,7 +11,7 @@ set -euxo pipefail
 
 function cleanup() {
 	rm -rf "$workdir"
-	rm -f "${target}.tmp"
+	[[ -n "$tmpfile" ]] && rm -f "$tmpfile"
 }
 
 function die() {


### PR DESCRIPTION
Backport of clean cherry-pick from master.