### PR TITLE
DLPX-83122 Add arm support to recovery-environment package

### DIFF
--- a/scripts/recovery_sync
+++ b/scripts/recovery_sync
@@ -85,7 +85,8 @@ for fmt in $(find /etc/ssh -name \*key | sed 's/.*host_\(.*\)_key/\1/'); do
 	#
 	cp "/etc/ssh/ssh_host_${fmt}_key" tmp.key
 	ssh-keygen -p -f tmp.key -N '' -P '' -m PEM
-	LD_LIBRARY_PATH="./usr/lib/x86_64-linux-gnu" ./usr/lib/dropbear/dropbearconvert \
+	arch_triple="$(dpkg-architecture -q DEB_HOST_MULTIARCH)"
+	LD_LIBRARY_PATH="./usr/lib/$arch_triple" ./usr/lib/dropbear/dropbearconvert \
 		openssh dropbear tmp.key "etc/dropbear/dropbear_${fmt}_host_key"
 	rm tmp.key
 done

--- a/scripts/stage1.sh
+++ b/scripts/stage1.sh
@@ -106,13 +106,16 @@ done
 ln -rs "$img/bin/busybox" "$img/bin/sh"
 ln -rs "$img/bin/sh" "$img/bin/bash"
 
-rsync -aKL "$workdir/lib64/ld-linux-x86-64.so.2" "$img/lib64/"
+loader_path="$(readelf -l /bin/ls | grep 'Requesting' | cut -d':' -f2 | tr -d ' ]')"
+arch_triple="$(dpkg-architecture -q DEB_HOST_MULTIARCH)"
+
+rsync -aKL "$workdir/$loader_path" "$img/$(dirname $loader_path)"
 mkdir -p "$img/usr/share/nginx"
 rsync -aKL "$workdir/usr/share/nginx/modules" "$img/usr/share/nginx/"
 rsync -aKL "$workdir/etc/nginx" "$img/etc/"
 rm "$img/etc/nginx/nginx.conf"
-mkdir -p "$img/lib/x86_64-linux-gnu/"
-rsync -aKL "$workdir"/lib/x86_64-linux-gnu/libnss* "$img/lib/x86_64-linux-gnu/"
+mkdir -p "$img/lib/$arch_triple/"
+rsync -aKL "$workdir/lib/$arch_triple"/libnss* "$img/lib/$arch_triple/"
 rsync -aK "$workdir/lib/modprobe.d" "$img/lib/"
 
 mkdir -p "$img"/etc/{systemd/network,network,dhcp}


### PR DESCRIPTION
Changes recovery environment build scripts to retrieve architecture information, rather than building specifically for amd64.

http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/3304/, also built on ARM version of bootstrap engine