### PR TITLE
TOOL-16770 Add rsync to package build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: recovery-environment
 Section: misc
 Priority: optional
 Maintainer: Paul Dagnelie <pcd@delphix.com>
-Build-Depends: debhelper (>= 10)
+Build-Depends: debhelper (>= 10), rsync
 Standards-Version: 4.1.2
 Vcs-Git: https://github.com/delphix/recovery-environment.git
 #Vcs-Browser: https://github.com/delphix/recovery-environment


### PR DESCRIPTION
The build depends on rsync, so we should list that in the build dependencies; this is required to build on a Delphix buildserver.