### PR TITLE
DLPX-92722 recovery-environment fails to build on 24.04 due to erroneous path

### DIFF
--- a/scripts/stage1.sh
+++ b/scripts/stage1.sh
@@ -29,7 +29,7 @@ function get_deps() {
 	#
 	sudo rm /etc/ld.so.cache
 	sudo ldconfig
-	(LD_LIBRARY_PATH="$(ldconfig -v 2>/dev/null | grep -v ^$'\t' | sed "s@^@$workdir@" | tr -d '\n'):$workdir/lib/systemd" \
+	(LD_LIBRARY_PATH="$(ldconfig -v 2>/dev/null | grep -v ^$'\t' | sed "s@^@$workdir@" | cut -d':' -f1 | paste -sd':' | tr -d '\n'):$workdir/usr/lib/x86_64-linux-gnu/systemd" \
 		ldd "$binary" 2>/dev/null || true) | while read -r line; do
 		if ! echo "$line" | grep "=>" &>/dev/null; then
 			continue
@@ -64,6 +64,7 @@ PACKAGES="dropbear-bin \
 	busybox-static \
 	kmod \
 	systemd \
+	systemd-resolved \
 	udev \
 	libssl1.1 \
 	nginx-extras"

--- a/scripts/stage1.sh
+++ b/scripts/stage1.sh
@@ -29,7 +29,7 @@ function get_deps() {
 	#
 	sudo rm /etc/ld.so.cache
 	sudo ldconfig
-	(LD_LIBRARY_PATH="$(ldconfig -v 2>/dev/null | grep -v ^$'\t' | sed "s@^@$workdir@" | cut -d':' -f1 | paste -sd':' | tr -d '\n'):$workdir/usr/lib/x86_64-linux-gnu/systemd" \
+	(LD_LIBRARY_PATH="$(ldconfig -v 2>/dev/null | grep -v ^$'\t' | sed "s@^@$workdir@" | cut -d':' -f1 | paste -sd':'):$workdir/usr/lib/x86_64-linux-gnu/systemd" \
 		ldd "$binary" 2>/dev/null || true) | while read -r line; do
 		if ! echo "$line" | grep "=>" &>/dev/null; then
 			continue


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build was run locally and any changes were pushed
- [ ] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

recovery-environment failed to build on 24.04. Here's an [example](https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/os-upgrade/job/build-package/job/recovery-environment/job/pre-push/1/consoleFull) 
```
16:41:57  + LD_LIBRARY_PATH='/tmp/tmp.cw5cz7ug8I/usr/lib/x86_64-linux-gnu/libfakeroot: (from /etc/ld.so.conf.d/fakeroot-x86_64-linux-gnu.conf:1)/tmp/tmp.cw5cz7ug8I/usr/local/lib: (from /etc/ld.so.conf.d/libc.conf:2)/tmp/tmp.cw5cz7ug8I/lib/x86_64-linux-gnu: (from /etc/ld.so.conf.d/x86_64-linux-gnu.conf:3)/tmp/tmp.cw5cz7ug8I/lib: (from <builtin>:0):/tmp/tmp.cw5cz7ug8I/lib/systemd'
16:41:57  + ldd /tmp/tmp.cw5cz7ug8I/img//bin/kmod
16:41:57  + echo 'linux-vdso.so.1 (0x00007ffcb678a000)'
16:41:57  + grep '=>'
16:41:57  + continue
16:41:57  + read -r line
16:41:57  + echo 'libzstd.so.1 => /lib/x86_64-linux-gnu/libzstd.so.1 (0x00007a7beee8b000)'
16:41:57  + grep '=>'
16:41:57  + local dep=
16:41:57  ++ echo 'libzstd.so.1 => /lib/x86_64-linux-gnu/libzstd.so.1 (0x00007a7beee8b000)'
16:41:57  ++ sed 's/.*=> \(.*\) (.*/\1/'
16:41:57  + dep=/lib/x86_64-linux-gnu/libzstd.so.1
16:41:57  + [[ /lib/x86_64-linux-gnu/libzstd.so.1 =~ /tmp/tmp.cw5cz7ug8I ]]
16:41:57  + die 'ldd found dependency outside of workdir'
16:41:57  + echo 'ldd found dependency outside of workdir'
16:41:57  ldd found dependency outside of workdir
16:41:57  + exit 1
16:41:57  make[1]: *** [Makefile:5: all] Error 1
16:41:57  make[1]: Leaving directory '/home/ubuntu/jenkins/workspace/linux-pkg/os-upgrade/build-package/recovery-environment/pre-push/linux-pkg/packages/recovery-environment/tmp/repo'
16:41:57  dh_auto_build: error: make -j2 returned exit code 2
16:41:57  make: *** [debian/rules:4: build] Error 25
16:41:57  dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
16:41:57  Error: failed command 'dpkg-buildpackage -b -us -uc'
```
Notice that the LDD_LIBRARY_PATH has those “from /etc/....” which is causing the path to be inferred incorrectly. Also, `systemd-resolved` was renamed to `resolvectl` and `systemd-resolved` now ships as a separate package beginning in 24.04: https://packages.ubuntu.com/search?keywords=systemd-resolved



## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fix `LDD_LIBRARY_PATH` such that it is inferred correctly. 
- Install systemd-resolved the same way the script installs systemd.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

build-package: https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/os-upgrade/job/build-package/job/recovery-environment/job/pre-push/4/console
