### PR TITLE
DLPX-94101 LTS 24.04: update recovery-environment for Ubuntu 24.04 appliance

### DIFF
--- a/scripts/stage1.sh
+++ b/scripts/stage1.sh
@@ -29,7 +29,7 @@ function get_deps() {
 	#
 	sudo rm /etc/ld.so.cache
 	sudo ldconfig
-	(LD_LIBRARY_PATH="$(ldconfig -v 2>/dev/null | grep -v ^$'\t' | sed "s@^@$workdir@" | tr -d '\n'):$workdir/lib/systemd" \
+	(LD_LIBRARY_PATH="$(ldconfig -v 2>/dev/null | grep -v ^$'\t' | sed "s@^@$workdir@" | cut -d':' -f1 | paste -sd':'):$workdir/usr/lib/x86_64-linux-gnu/systemd" \
 		ldd "$binary" 2>/dev/null || true) | while read -r line; do
 		if ! echo "$line" | grep "=>" &>/dev/null; then
 			continue
@@ -64,6 +64,7 @@ PACKAGES="dropbear-bin \
 	busybox-static \
 	kmod \
 	systemd \
+	systemd-resolved \
 	udev \
 	libssl1.1 \
 	nginx-extras"


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
We need to port the changes made on the os-upgrade branch to develop, for the 2025.4.0.0 release.
</details>

<details open>
<summary><h2> Solution </h2></summary>

- Note, this will need to be integrated simultaneously with all the other LTS changes on other repositories, after code-complete.
- This PR has all the changes made on the os-upgrade branch, cherry-picked and squashed into a single commit for integration on the develop branch.
  - DLPX-92722 recovery-environment fails to build on 24.04 due to erroneous path (#44)
  
</details>

